### PR TITLE
Minor fix: asterisk inconsistencies

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -20,12 +20,12 @@ struct ExecutionContext {
             uint8_t p : 2;
         };
     };
-    uint8_t (*n)(struct ExecutionContext*);
-    uint16_t (*nn)(struct ExecutionContext*);
-    int8_t (*d)(struct ExecutionContext*);
+    uint8_t (*n)(struct ExecutionContext *);
+    uint16_t (*nn)(struct ExecutionContext *);
+    int8_t (*d)(struct ExecutionContext *);
 };
 
-z80cpu_t* cpu_init(void) {
+z80cpu_t *cpu_init(void) {
     z80cpu_t *cpu = calloc(1, sizeof(z80cpu_t));
     z80iodevice_t nullDevice = { NULL, NULL, NULL };
     int i;
@@ -35,33 +35,33 @@ z80cpu_t* cpu_init(void) {
     return cpu;
 }
 
-void cpu_free(z80cpu_t* cpu) {
+void cpu_free(z80cpu_t *cpu) {
     free(cpu);
 }
 
-uint8_t cpu_read_byte(z80cpu_t* cpu, uint16_t address) {
+uint8_t cpu_read_byte(z80cpu_t *cpu, uint16_t address) {
     return cpu->read_byte(cpu->memory, address);
 }
 
-void cpu_write_byte(z80cpu_t* cpu, uint16_t address, uint8_t value) {
+void cpu_write_byte(z80cpu_t *cpu, uint16_t address, uint8_t value) {
     cpu->write_byte(cpu->memory, address, value);
 }
 
-uint16_t cpu_read_word(z80cpu_t* cpu, uint16_t address) {
+uint16_t cpu_read_word(z80cpu_t *cpu, uint16_t address) {
     return cpu->read_byte(cpu->memory, address) | (cpu->read_byte(cpu->memory, address + 1) << 8);
 }
 
-void cpu_write_word(z80cpu_t* cpu, uint16_t address, uint16_t value) {
+void cpu_write_word(z80cpu_t *cpu, uint16_t address, uint16_t value) {
     cpu->write_byte(cpu->memory, address, value & 0xFF);
     cpu->write_byte(cpu->memory, address + 1, value >> 8);
 }
 
-void push(z80cpu_t* cpu, uint16_t value) {
+void push(z80cpu_t *cpu, uint16_t value) {
     cpu_write_word(cpu, cpu->registers.SP - 2, value);
     cpu->registers.SP -= 2;
 }
 
-uint16_t pop(z80cpu_t* cpu) {
+uint16_t pop(z80cpu_t *cpu) {
     uint16_t a = 0;
     a |= cpu_read_byte(cpu, cpu->registers.SP++);
     a |= cpu_read_byte(cpu, cpu->registers.SP++) << 8;
@@ -83,7 +83,7 @@ int8_t read_d(struct ExecutionContext *context) {
     return (int8_t)cpu_read_byte(context->cpu, context->cpu->registers.PC++);
 }
 
-uint8_t HorIHr(struct ExecutionContext* context) {
+uint8_t HorIHr(struct ExecutionContext *context) {
     if (context->cpu->prefix == 0xDD) {
         return context->cpu->registers.IXH;
     } else if (context->cpu->prefix == 0xFD) {
@@ -93,7 +93,7 @@ uint8_t HorIHr(struct ExecutionContext* context) {
     }
 }
 
-uint8_t HorIHw(struct ExecutionContext* context, uint8_t value) {
+uint8_t HorIHw(struct ExecutionContext *context, uint8_t value) {
     if (context->cpu->prefix == 0xDD) {
         context->cpu->registers.IXH = value;
     } else if (context->cpu->prefix == 0xFD) {
@@ -104,7 +104,7 @@ uint8_t HorIHw(struct ExecutionContext* context, uint8_t value) {
     return value;
 }
 
-uint8_t LorILr(struct ExecutionContext* context) {
+uint8_t LorILr(struct ExecutionContext *context) {
     if (context->cpu->prefix == 0xDD) {
         return context->cpu->registers.IXL;
     } else if (context->cpu->prefix == 0xFD) {
@@ -114,7 +114,7 @@ uint8_t LorILr(struct ExecutionContext* context) {
     }
 }
 
-uint8_t LorILw(struct ExecutionContext* context, uint8_t value) {
+uint8_t LorILw(struct ExecutionContext *context, uint8_t value) {
     if (context->cpu->prefix == 0xDD) {
         context->cpu->registers.IXL = value;
     } else if (context->cpu->prefix == 0xFD) {
@@ -125,7 +125,7 @@ uint8_t LorILw(struct ExecutionContext* context, uint8_t value) {
     return value;
 }
 
-uint16_t HLorIr(struct ExecutionContext* context) {
+uint16_t HLorIr(struct ExecutionContext *context) {
     if (context->cpu->prefix == 0xDD) {
         return context->cpu->registers.IX;
     } else if (context->cpu->prefix == 0xFD) {
@@ -135,7 +135,7 @@ uint16_t HLorIr(struct ExecutionContext* context) {
     }
 }
 
-uint16_t HLorIw(struct ExecutionContext* context, uint16_t value) {
+uint16_t HLorIw(struct ExecutionContext *context, uint16_t value) {
     if (context->cpu->prefix == 0xDD) {
         context->cpu->registers.IX = value;
     } else if (context->cpu->prefix == 0xFD) {
@@ -146,7 +146,7 @@ uint16_t HLorIw(struct ExecutionContext* context, uint16_t value) {
     return value;
 }
 
-uint8_t indHLorIr(struct ExecutionContext* context) {
+uint8_t indHLorIr(struct ExecutionContext *context) {
     // This function erases the prefix early so that the next read (H or L) does not
     // use IXH or IXL
     if (context->cpu->prefix == 0xDD) {
@@ -162,7 +162,7 @@ uint8_t indHLorIr(struct ExecutionContext* context) {
     }
 }
 
-uint8_t indHLorIw(struct ExecutionContext* context, uint8_t value) {
+uint8_t indHLorIw(struct ExecutionContext *context, uint8_t value) {
     if (context->cpu->prefix == 0xDD) {
         context->cycles += 9;
         context->cpu->prefix = 0;
@@ -353,7 +353,7 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
     }
 }
 
-void execute_rot(int y, int z, struct ExecutionContext* context) {
+void execute_rot(int y, int z, struct ExecutionContext *context) {
     uint8_t r = read_r(z, context);
     uint8_t old_r = r;
     uint8_t old_7 = (r & 0x80) > 0;
@@ -420,7 +420,7 @@ void execute_rot(int y, int z, struct ExecutionContext* context) {
     }
 }
 
-void execute_im(int y, struct ExecutionContext* context) {
+void execute_im(int y, struct ExecutionContext *context) {
     switch (y) {
         case 0: context->cpu->int_mode = 0; break;
         case 1: context->cpu->int_mode = 0; break; // 0/1
@@ -433,7 +433,7 @@ void execute_im(int y, struct ExecutionContext* context) {
     }
 }
 
-int cpu_execute(z80cpu_t* cpu, int cycles) {
+int cpu_execute(z80cpu_t *cpu, int cycles) {
     struct ExecutionContext context;
     context.cpu = cpu;
     while (cycles > 0) {

--- a/main.c
+++ b/main.c
@@ -1,8 +1,9 @@
-#include "asic.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <strings.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include "asic.h"
 
 typedef struct {
     ti_device_type device;
@@ -26,7 +27,7 @@ appContext_t create_context(void) {
     return context;
 }
 
-void setDevice(appContext_t *context, char* target) {
+void setDevice(appContext_t *context, char *target) {
     if (strcasecmp(target, "TI73") == 0) {
         context->device = TI73;
     } else if (strcasecmp(target, "TI83p") == 0) {

--- a/tests/io.c
+++ b/tests/io.c
@@ -1,9 +1,9 @@
-uint8_t test_read(void* device) {
-    return *(uint8_t*)device;
+uint8_t test_read(void *device) {
+    return *(uint8_t *)device;
 }
 
-void test_write(void* device, uint8_t value) {
-    *(uint8_t*)device = value;
+void test_write(void *device, uint8_t value) {
+    *(uint8_t *)device = value;
 }
 
 int test_OUT_n_A() {

--- a/ti/asic.c
+++ b/ti/asic.c
@@ -1,22 +1,18 @@
 #include "asic.h"
-#include "memory.h"
-#include "cpu.h"
-#include <stdint.h>
-#include <stdlib.h>
 
-uint8_t asic_test_device_in(void* device);
+uint8_t asic_test_device_in(void *device);
 
 asic_t* asic_init(ti_device_type type) {
-    asic_t* device = malloc(sizeof(asic_t));
+    asic_t *device = malloc(sizeof(asic_t));
     device->cpu = cpu_init();
     device->mmu = ti_mmu_init(type);
-    device->cpu->memory = (void*)device->mmu;
+    device->cpu->memory = (void *)device->mmu;
     device->cpu->read_byte = ti_read_byte;
     device->cpu->write_byte = ti_write_byte;
     return device;
 }
 
-void asic_free(asic_t* device) {
+void asic_free(asic_t *device) {
     cpu_free(device->cpu);
     ti_mmu_free(device->mmu);
     free(device);

--- a/ti/asic.h
+++ b/ti/asic.h
@@ -1,17 +1,19 @@
 #ifndef ASIC_H
 #define ASIC_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
 #include "cpu.h"
 #include "memory.h"
 #include "ti.h"
-#include <stdint.h>
-
 
 typedef struct {
-    z80cpu_t* cpu;
-    ti_mmu_t* mmu;
+    z80cpu_t *cpu;
+    ti_mmu_t *mmu;
 } asic_t;
 
-asic_t* asic_init(ti_device_type);
-void asic_free(asic_t*);
+asic_t *asic_init(ti_device_type);
+void asic_free(asic_t *);
 
 #endif

--- a/ti/memory.c
+++ b/ti/memory.c
@@ -1,13 +1,7 @@
 #include "memory.h"
-#include "cpu.h"
-#include "ti.h"
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 
-ti_mmu_t* ti_mmu_init(ti_device_type device_type) {
-    ti_mmu_t* mmu = malloc(sizeof(ti_mmu_t));
+ti_mmu_t *ti_mmu_init(ti_device_type device_type) {
+    ti_mmu_t *mmu = malloc(sizeof(ti_mmu_t));
     mmu->settings = malloc(sizeof(ti_mmu_settings_t));
     switch (device_type) {
         case TI83p:

--- a/ti/memory.h
+++ b/ti/memory.h
@@ -1,8 +1,13 @@
 #ifndef MEMORY_H
 #define MEMORY_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "cpu.h"
 #include "ti.h"
-#include <stdint.h>
 
 typedef struct {
     uint16_t ram_pages;
@@ -15,14 +20,14 @@ typedef struct {
 } ti_mmu_bank_state_t;
 
 typedef struct {
-    ti_mmu_settings_t* settings;
+    ti_mmu_settings_t *settings;
     ti_mmu_bank_state_t banks[4];
-    uint8_t* ram;
-    uint8_t* flash;
+    uint8_t *ram;
+    uint8_t *flash;
     int flash_unlocked;
 } ti_mmu_t;
 
-ti_mmu_t* ti_mmu_init(ti_device_type);
+ti_mmu_t *ti_mmu_init(ti_device_type);
 void ti_mmu_free(ti_mmu_t *mmu);
 uint8_t ti_read_byte(void *memory, uint16_t address);
 void ti_write_byte(void *memory, uint16_t address, uint8_t value);


### PR DESCRIPTION
Your team is inconsistent with their asterisk placement.
I quickly fixed them up as I was getting familiar with the codebase.

Consider what happens when you declare:

```
int* a,b,c;  <-- a is an int *, but b and c are just int.
int *a,b,*c,d,*e,*f; <-- is now a lot more clear.
```

As a reference, here's the two possible placements:

```
char* x; <-- x is a char *
char *x; <-- *x is a char
```

In C, declaration follows usages, therefore the latter is preferable (read idiomatic).
