### PR TITLE
Improve hexdump output

### DIFF
--- a/debugger/commands/hexdump.c
+++ b/debugger/commands/hexdump.c
@@ -52,7 +52,7 @@ int command_hexdump(struct debugger_state *state, int argc, char **argv) {
     }
 
     state->print(state, "%*s |", (16 - count) * 3, " ");
-    for (j = 0; j < 16; j++) {
+    for (j = 0; j < count; j++) {
         char byte = ti_read_byte(mmu, start + i + j);
         if (isprint(byte) && byte != '\t') {
             state->print(state, "%c", byte);


### PR DESCRIPTION
As it says on the tin. Looks like this now:

```
 z80e > h 0 34
0000 FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  |................|
0010 FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  |................|
0020 FF FF                                            |..|
```
