### PR TITLE
Improve Emulation Accuracy

### DIFF
--- a/frontends/test/tests/load.c
+++ b/frontends/test/tests/load.c
@@ -282,8 +282,8 @@ int test_RRD_RLD() {
 	cpu_write_word(device->cpu, 0xC000, 0x3456);
 	flash(device, test, sizeof(test));
 	int cycles = cpu_execute(device->cpu, 18);
-	if (device->cpu->registers.A != 0x56 ||
-			cpu_read_word(device->cpu, 0xC000) != 0x1234 ||
+	if (device->cpu->registers.A != 0x16 ||
+			cpu_read_word(device->cpu, 0xC000) != 0x3425 ||
 			cycles != 0) {
 		asic_free(device);
 		return 1;

--- a/libz80e/include/z80e/core/registers.h
+++ b/libz80e/include/z80e/core/registers.h
@@ -87,8 +87,7 @@ typedef enum {
 void exAFAF(z80registers_t *r);
 void exDEHL(z80registers_t *r);
 void exx(z80registers_t *r);
-void updateParity(z80registers_t *r, uint32_t newValue);
-int popcount(uint64_t x);
+int parity(uint8_t x);
 
 // S Z 5 H 3 PV N C
 #define __flag_s(a)  ((a) ? FLAG_S  : 0)
@@ -104,7 +103,7 @@ int popcount(uint64_t x);
 #define _flag_sign_16(a)  __flag_s((a) & 0x8000)
 #define _flag_sign_8(a)   __flag_s((a) & 0x80)
 
-#define _flag_parity(a) __flag_pv(!(popcount(a) % 2))
+#define _flag_parity(a) __flag_pv(!parity(a))
 
 #define _flag_undef_8(a) ({ uint8_t _res = (a); __flag_5(_res & 0x20) | __flag_3(_res & 0x8);})
 #define _flag_undef_16(a) ({ uint16_t _res = (a); __flag_5(_res & 0x2000) | __flag_3(_res & 0x800);})

--- a/libz80e/include/z80e/core/registers.h
+++ b/libz80e/include/z80e/core/registers.h
@@ -117,10 +117,10 @@ int parity(uint8_t x);
 		(op1 & 0x80) != (result & 0x80))
 #define _flag_overflow_16_sub(op1, op2, result) __flag_pv((op1 & 0x8000) != (op2 & 0x8000) && (op1 & 0x8000) != (result & 0x8000))
 
-#define _flag_halfcarry_8_add(op1, op2) __flag_h(((op1 & 0xf) + (op2 & 0xf)) & 0x10)
-#define _flag_halfcarry_8_sub(op1, op2) __flag_h(((op1 & 0xf) - (op2 & 0xf)) & 0x10)
-#define _flag_halfcarry_16_add(op1, op2) __flag_h(((op1 & 0xfff) + (op2 & 0xfff)) & 0x1000)
-#define _flag_halfcarry_16_sub(op1, op2) __flag_h(((op1 & 0xfff) - (op2 & 0xfff)) & 0x1000)
+#define _flag_halfcarry_8_add(op1, op2, carry) __flag_h(((op1 & 0xf) + (op2 & 0xf) + carry) & 0x10)
+#define _flag_halfcarry_8_sub(op1, op2, carry) __flag_h(((op1 & 0xf) - (op2 & 0xf) - carry) & 0x10)
+#define _flag_halfcarry_16_add(op1, op2, carry) __flag_h(((op1 & 0xfff) + (op2 & 0xfff) + carry) & 0x1000)
+#define _flag_halfcarry_16_sub(op1, op2, carry) __flag_h(((op1 & 0xfff) - (op2 & 0xfff) - carry) & 0x1000)
 
 #define _flag_subtract(a)   ((a) ? FLAG_N : 0)
 #define _flag_zero(a)       ((a) ? 0 : FLAG_Z)

--- a/libz80e/include/z80e/core/registers.h
+++ b/libz80e/include/z80e/core/registers.h
@@ -109,12 +109,8 @@ int parity(uint8_t x);
 #define _flag_undef_16(a) ({ uint16_t _res = (a); __flag_5(_res & 0x2000) | __flag_3(_res & 0x800);})
 
 #define _flag_overflow_8_add(op1, op2, result) __flag_pv((op1 & 0x80) == (op2 & 0x80) && (op1 & 0x80) != (result & 0x80))
+#define _flag_overflow_8_sub(op1, op2, result) __flag_pv((op1 & 0x80) != (op2 & 0x80) && (op1 & 0x80) != (result & 0x80))
 #define _flag_overflow_16_add(op1, op2, result) __flag_pv((op1 & 0x8000) == (op2 & 0x8000) && (op1 & 0x8000) != (result & 0x8000))
-
-#define _flag_overflow_8_sub(op1, op2, result) \
-	__flag_pv( \
-		(op1 & 0x80) != (op2 & 0x80) && \
-		(op1 & 0x80) != (result & 0x80))
 #define _flag_overflow_16_sub(op1, op2, result) __flag_pv((op1 & 0x8000) != (op2 & 0x8000) && (op1 & 0x8000) != (result & 0x8000))
 
 #define _flag_halfcarry_8_add(op1, op2, carry) __flag_h(((op1 & 0xf) + (op2 & 0xf) + carry) & 0x10)

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -1098,7 +1098,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						new |= old << 4;
 						cpu_write_byte(cpu, r->HL, new);
 						r->F = __flag_c(r->flags.C) | _flag_sign_8(r->A) | _flag_zero(r->A)
-							| _flag_parity(r->A) | _flag_undef_8(new);
+							| _flag_parity(r->A) | _flag_undef_8(r->A);
 						break;
 					case 5: // RLD
 						context.cycles += 14;
@@ -1110,7 +1110,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						new |= old & 0x0F;
 						cpu_write_byte(cpu, r->HL, new);
 						r->F = __flag_c(r->flags.C) | _flag_sign_8(r->A) | _flag_zero(r->A)
-							| _flag_parity(r->A) | _flag_undef_8(new);
+							| _flag_parity(r->A) | _flag_undef_8(r->A);
 						break;
 					default: // NOP (invalid instruction)
 						context.cycles += 4;

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -499,7 +499,7 @@ void daa(struct ExecutionContext *context) {
 
 	r->flags.Z = r->A == 0;
 	r->flags.S = (r->A & 0x80) == 0x80;
-	r->flags.PV = !(popcount(r->A) % 2);
+	r->flags.PV = !parity(r->A);
 }
 
 void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -525,7 +525,7 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 		old = r->A;
 		r->A += v + r->flags.C;
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
-			| _flag_undef_8(r->A) | _flag_overflow_8_add(old, v + r->flags.C, r->A)
+			| _flag_undef_8(r->A) | _flag_overflow_8_add(old, v, r->A)
 			| _flag_subtract(0) | _flag_carry_8(old + v + r->flags.C)
 			| _flag_halfcarry_8_add(old, v, r->flags.C);
 		break;
@@ -1011,7 +1011,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						op16 = read_rp(context.p, &context);
 						r->HL -= op16 + r->flags.C;
 						r->F = _flag_sign_16(r->HL) | _flag_zero(r->HL)
-							| _flag_undef_16(r->HL) | _flag_overflow_16_sub(old16, op16 + r->flags.C, r->HL)
+							| _flag_undef_16(r->HL) | _flag_overflow_16_sub(old16, op16, r->HL)
 							| _flag_subtract(1) | _flag_carry_16(old16 - op16 - r->flags.C)
 							| _flag_halfcarry_16_sub(old16, op16, r->flags.C);
 					} else { // ADC HL, rp[p]
@@ -1020,7 +1020,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						op16 = read_rp(context.p, &context);
 						r->HL += op16 + r->flags.C;
 						r->F = _flag_sign_16(r->HL) | _flag_zero(r->HL)
-							| _flag_undef_16(r->HL) | _flag_overflow_16_add(old16, op16 + r->flags.C, r->HL)
+							| _flag_undef_16(r->HL) | _flag_overflow_16_add(old16, op16, r->HL)
 							| _flag_subtract(0) | _flag_carry_16(old16 + op16 + r->flags.C)
 							| _flag_halfcarry_16_add(old16, op16, r->flags.C);
 					}

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -498,13 +498,13 @@ void daa(struct ExecutionContext *context) {
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 			| _flag_undef_8(r->A) | _flag_parity(r->A)
 			| _flag_subtract(r->flags.N) | __flag_c(v >= 0x60)
-			| _flag_halfcarry_8_sub(old, v);
+			| _flag_halfcarry_8_sub(old, v, 0);
 	} else {
 		r->A += v;
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 			| _flag_undef_8(r->A) | _flag_parity(r->A)
 			| _flag_subtract(r->flags.N) | __flag_c(v >= 0x60)
-			| _flag_halfcarry_8_add(old, v);
+			| _flag_halfcarry_8_add(old, v, 0);
 	}
 }
 
@@ -516,11 +516,10 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 	case 0: // ADD A, v
 		old = r->A;
 		r->A += v;
-
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 			| _flag_undef_8(r->A) | _flag_overflow_8_add(old, v, r->A)
 			| _flag_subtract(0) | _flag_carry_8(old + v)
-			| _flag_halfcarry_8_add(old, v);
+			| _flag_halfcarry_8_add(old, v, 0);
 		break;
 	case 1: // ADC A, v
 		old = r->A;
@@ -528,7 +527,7 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 			| _flag_undef_8(r->A) | _flag_overflow_8_add(old, v + r->flags.C, r->A)
 			| _flag_subtract(0) | _flag_carry_8(old + v + r->flags.C)
-			| _flag_halfcarry_8_add(old, v + r->flags.C);
+			| _flag_halfcarry_8_add(old, v, r->flags.C);
 		break;
 	case 2: // SUB v
 		old = r->A;
@@ -536,7 +535,7 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 			| _flag_undef_8(r->A) | _flag_overflow_8_sub(old, v, r->A)
 			| _flag_subtract(1) | _flag_carry_8(old - v)
-			| _flag_halfcarry_8_sub(old, v);
+			| _flag_halfcarry_8_sub(old, v, 0);
 		break;
 	case 3: // SBC v
 		old = r->A;
@@ -544,7 +543,7 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 		r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 			| _flag_undef_8(r->A) | _flag_overflow_8_sub(old, v, r->A)
 			| _flag_subtract(1) | _flag_carry_8(old - v - r->flags.C)
-			| _flag_halfcarry_8_sub(old, v + r->flags.C);
+			| _flag_halfcarry_8_sub(old, v, r->flags.C);
 		break;
 	case 4: // AND v
 		old = r->A;
@@ -571,7 +570,7 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 			| _flag_undef_8(v) | _flag_subtract(1)
 			| _flag_carry_8(r->A - v)
 			| _flag_overflow_8_sub(r->A, v, old)
-			| _flag_halfcarry_8_sub(r->A, v);
+			| _flag_halfcarry_8_sub(r->A, v, 0);
 		break;
 	}
 }
@@ -661,7 +660,7 @@ void execute_bli(int y, int z, struct ExecutionContext *context) {
 			new = cpu_read_byte(context->cpu, r->HL++);
 			uint8_t aminushl = r->A - new;
 			r->F = _flag_sign_8(aminushl) | _flag_zero(aminushl)
-				| _flag_halfcarry_8_sub(r->A, new)
+				| _flag_halfcarry_8_sub(r->A, new, 0)
 				| __flag_pv(!--r->BC) | _flag_subtract(1)
 				| __flag_c(r->flags.C);
 			break;
@@ -700,7 +699,7 @@ void execute_bli(int y, int z, struct ExecutionContext *context) {
 			new = cpu_read_byte(context->cpu, r->HL--);
 			uint8_t aminushl = r->A - new;
 			r->F = _flag_sign_8(aminushl) | _flag_zero(aminushl)
-				| _flag_halfcarry_8_sub(r->A, new)
+				| _flag_halfcarry_8_sub(r->A, new, 0)
 				| __flag_pv(!--r->BC) | _flag_subtract(1)
 				| __flag_c(r->flags.C);
 			break;
@@ -743,7 +742,7 @@ void execute_bli(int y, int z, struct ExecutionContext *context) {
 			new = cpu_read_byte(context->cpu, r->HL++);
 			uint8_t aminushl = r->A - new;
 			r->F = _flag_sign_8(aminushl) | _flag_zero(aminushl)
-				| _flag_halfcarry_8_sub(r->A, new)
+				| _flag_halfcarry_8_sub(r->A, new, 0)
 				| __flag_pv(!--r->BC) | _flag_subtract(1)
 				| __flag_c(r->flags.C);
 			if (r->BC && !r->flags.Z) {
@@ -798,7 +797,7 @@ void execute_bli(int y, int z, struct ExecutionContext *context) {
 			new = cpu_read_byte(context->cpu, r->HL--);
 			uint8_t aminushl = r->A - new;
 			r->F = _flag_sign_8(aminushl) | _flag_zero(aminushl)
-				| _flag_halfcarry_8_sub(r->A, new)
+				| _flag_halfcarry_8_sub(r->A, new, 0)
 				| __flag_pv(!--r->BC) | _flag_subtract(1)
 				| __flag_c(r->flags.C);
 			if (r->BC && !r->flags.Z) {
@@ -1009,21 +1008,21 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 					if (context.q == 0) { // SBC HL, rp[p]
 						context.cycles += 11;
 						old16 = r->HL;
-						op16 = read_rp(context.p, &context) + r->flags.C;
-						r->HL -= op16;
+						op16 = read_rp(context.p, &context);
+						r->HL -= op16 + r->flags.C;
 						r->F = _flag_sign_16(r->HL) | _flag_zero(r->HL)
-							| _flag_undef_16(r->HL) | _flag_overflow_16_sub(old16, op16, r->HL)
-							| _flag_subtract(1) | _flag_carry_16(old16 - op16)
-							| _flag_halfcarry_16_sub(old16, op16);
+							| _flag_undef_16(r->HL) | _flag_overflow_16_sub(old16, op16 + r->flags.C, r->HL)
+							| _flag_subtract(1) | _flag_carry_16(old16 - op16 - r->flags.C)
+							| _flag_halfcarry_16_sub(old16, op16, r->flags.C);
 					} else { // ADC HL, rp[p]
 						context.cycles += 11;
 						old16 = r->HL;
-						op16 = read_rp(context.p, &context) + r->flags.C;
-						r->HL += op16;
+						op16 = read_rp(context.p, &context);
+						r->HL += op16 + r->flags.C;
 						r->F = _flag_sign_16(r->HL) | _flag_zero(r->HL)
-							| _flag_undef_16(r->HL) | _flag_overflow_16_add(old16, op16, r->HL)
-							| _flag_subtract(0) | _flag_carry_16(old16 + op16)
-							| _flag_halfcarry_16_add(old16, op16);
+							| _flag_undef_16(r->HL) | _flag_overflow_16_add(old16, op16 + r->flags.C, r->HL)
+							| _flag_subtract(0) | _flag_carry_16(old16 + op16 + r->flags.C)
+							| _flag_halfcarry_16_add(old16, op16, r->flags.C);
 					}
 					break;
 				case 3:
@@ -1043,7 +1042,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 					r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 						| _flag_undef_8(r->A) | __flag_pv(old == 0x80)
 						| _flag_subtract(1) | __flag_c(old != 0)
-						| _flag_halfcarry_8_sub(old, (old - new) & 0xff);
+						| _flag_halfcarry_8_sub(old, (old - new) & 0xff, 0);
 					break;
 				case 5:
 					if (context.y == 1) { // RETI
@@ -1186,7 +1185,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						r->F = __flag_s(r->flags.S) | _flag_zero(!r->flags.Z)
 							| _flag_undef_16(new16) | __flag_pv(r->flags.PV)
 							| _flag_subtract(0) | _flag_carry_16(old16 + op16)
-							| _flag_halfcarry_16_add(old16, op16);
+							| _flag_halfcarry_16_add(old16, op16, 0);
 						break;
 					}
 					break;
@@ -1256,7 +1255,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 
 					new = write_r(context.y, old + 1, &context);
 					r->F = __flag_c(r->flags.C) | _flag_sign_8(new) | _flag_zero(new)
-						| _flag_halfcarry_8_add(old, 1) | __flag_pv(old == 0x7F)
+						| _flag_halfcarry_8_add(old, 0, 1) | __flag_pv(old == 0x7F)
 						| _flag_undef_8(new);
 					break;
 				case 5: // DEC r[y]
@@ -1268,7 +1267,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 
 					new = write_r(context.y, old - 1, &context);
 					r->F = __flag_c(r->flags.C) | _flag_sign_8(new) | _flag_zero(new)
-						| _flag_halfcarry_8_sub(old, 1) | __flag_pv(old == 0x80)
+						| _flag_halfcarry_8_sub(old, 0, 1) | __flag_pv(old == 0x80)
 						| _flag_subtract(1) | _flag_undef_8(new);
 					break;
 				case 6: // LD r[y], n

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -1298,6 +1298,8 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						r->A <<= 1;
 						r->A |= old;
 						r->flags.N = r->flags.H = 0;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					case 1: // RRCA
 						context.cycles += 4;
@@ -1306,6 +1308,8 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						r->A >>= 1;
 						r->A |= old << 7;
 						r->flags.N = r->flags.H = 0;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					case 2: // RLA
 						context.cycles += 4;
@@ -1314,6 +1318,8 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						r->A <<= 1;
 						r->A |= old;
 						r->flags.N = r->flags.H = 0;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					case 3: // RRA
 						context.cycles += 4;
@@ -1322,6 +1328,8 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						r->A >>= 1;
 						r->A |= old << 7;
 						r->flags.N = r->flags.H = 0;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					case 4: // DAA
 						context.cycles += 4;

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -1091,20 +1091,26 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 					case 4: // RRD
 						context.cycles += 14;
 						old = r->A;
-						old16 = cpu_read_word(cpu, r->HL);
-						r->A = old16 & 0xFF;
-						old16 >>= 8;
-						old16 |= old << 8;
-						cpu_write_word(cpu, r->HL, old16);
+						new = cpu_read_byte(cpu, r->HL);
+						r->A &= 0xF0;
+						r->A |= new & 0x0F;
+						new >>= 4;
+						new |= old << 4;
+						cpu_write_byte(cpu, r->HL, new);
+						r->F = __flag_c(r->flags.C) | _flag_sign_8(r->A) | _flag_zero(r->A)
+							| _flag_parity(r->A) | _flag_undef_8(new);
 						break;
 					case 5: // RLD
 						context.cycles += 14;
 						old = r->A;
-						old16 = cpu_read_word(cpu, r->HL);
-						r->A = old16 >> 8;
-						old16 <<= 8;
-						old16 |= old;
-						cpu_write_word(cpu, r->HL, old16);
+						new = cpu_read_byte(cpu, r->HL);
+						r->A &= 0xF0;
+						r->A |= new >> 4;
+						new <<= 4;
+						new |= old & 0x0F;
+						cpu_write_byte(cpu, r->HL, new);
+						r->F = __flag_c(r->flags.C) | _flag_sign_8(r->A) | _flag_zero(r->A)
+							| _flag_parity(r->A) | _flag_undef_8(new);
 						break;
 					default: // NOP (invalid instruction)
 						context.cycles += 4;

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -477,8 +477,8 @@ uint8_t read_cc(int i, struct ExecutionContext *context) {
 	case 3: return  r->flags.C;
 	case 4: return !r->flags.PV;
 	case 5: return  r->flags.PV;
-	case 6: return !r->flags.N;
-	case 7: return  r->flags.N;
+	case 6: return !r->flags.S;
+	case 7: return  r->flags.S;
 	}
 	return 0; // This should never happen
 }

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -931,9 +931,10 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 			case 1: // BIT y, r[z]
 				context.cycles += 4;
 				old = read_r(context.z, &context);
-				r->flags.H = 1;
-				r->flags.N = 0;
-				cpu->registers.flags.Z = (old & (1 << context.y)) == 0;
+				old &= 1 << context.y;
+				r->F = _flag_sign_8(old) | _flag_zero(old)
+					| _flag_parity(old) | __flag_c(r->flags.C)
+					| FLAG_H;
 				break;
 			case 2: // RES y, r[z]
 				context.cycles += 4;

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -1043,7 +1043,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 					r->F = _flag_sign_8(r->A) | _flag_zero(r->A)
 						| _flag_undef_8(r->A) | __flag_pv(old == 0x80)
 						| _flag_subtract(1) | __flag_c(old != 0)
-						| _flag_halfcarry_8_sub(old, (old - new) & 0xff, 0);
+						| _flag_halfcarry_8_sub(0, old, 0);
 					break;
 				case 5:
 					if (context.y == 1) { // RETI

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -1340,17 +1340,23 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						context.cycles += 4;
 						r->A = ~r->A;
 						r->flags.N = r->flags.H = 1;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					case 6: // SCF
 						context.cycles += 4;
 						r->flags.C = 1;
 						r->flags.N = r->flags.H = 0;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					case 7: // CCF
 						context.cycles += 4;
 						r->flags.H = r->flags.C;
 						r->flags.C = !r->flags.C;
 						r->flags.N = 0;
+						r->flags._3 = (r->A & FLAG_3) > 0;
+						r->flags._5 = (r->A & FLAG_5) > 0;
 						break;
 					}
 					break;

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -1183,8 +1183,10 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 						old16 = HLorIr(&context);
 						op16 = read_rp(context.p, &context);
 						new16 = HLorIw(&context, old16 + op16);
-						r->F = _flag_zero(!r->flags.Z) | __flag_s(r->flags.S) | __flag_pv(r->flags.PV)
-							| _flag_subtract(0) | _flag_carry_16(old16 + op16) | _flag_halfcarry_16_add(old16, op16);
+						r->F = __flag_s(r->flags.S) | _flag_zero(!r->flags.Z)
+							| _flag_undef_16(new16) | __flag_pv(r->flags.PV)
+							| _flag_subtract(0) | _flag_carry_16(old16 + op16)
+							| _flag_halfcarry_16_add(old16, op16);
 						break;
 					}
 					break;

--- a/libz80e/src/core/cpu.c
+++ b/libz80e/src/core/cpu.c
@@ -575,9 +575,9 @@ void execute_alu(int i, uint8_t v, struct ExecutionContext *context) {
 	}
 }
 
-void execute_rot(int y, int z, struct ExecutionContext *context) {
+void execute_rot(int y, int z, int switch_opcode_data, struct ExecutionContext *context) {
 	uint8_t r = read_r(z, context);
-	if (z == 6) {
+	if (z == 6 && switch_opcode_data) {
 		// reset the PC back to the offset, so
 		// the write reads it correctly
 		context->cpu->registers.PC--;
@@ -926,7 +926,7 @@ int cpu_execute(z80cpu_t *cpu, int cycles) {
 			switch (context.x) {
 			case 0: // rot[y] r[z]
 				context.cycles += 4;
-				execute_rot(context.y, context.z, &context);
+				execute_rot(context.y, context.z, switch_opcode_data, &context);
 				break;
 			case 1: // BIT y, r[z]
 				context.cycles += 4;

--- a/libz80e/src/core/registers.c
+++ b/libz80e/src/core/registers.c
@@ -21,15 +21,11 @@ void exx(z80registers_t *r) {
 	temp = r->_BC; r->_BC = r->BC; r->BC = temp;
 }
 
-const uint64_t m1  = 0x5555555555555555;
-const uint64_t m2  = 0x3333333333333333;
-const uint64_t m4  = 0x0f0f0f0f0f0f0f0f;
-const uint64_t h01 = 0x0101010101010101;
-int popcount(uint64_t x) {
-	x -= (x >> 1) & m1;
-	x = (x & m2) + ((x >> 2) & m2);
-	x = (x + (x >> 4)) & m4;
-	return (x * h01) >> 56;
+int parity(uint8_t x) {
+  x ^= x >> 4;
+  x ^= x >> 2;
+  x ^= x >> 1;
+  return x & 1;
 }
 
 void print_state(z80registers_t *r) {

--- a/libz80e/src/core/registers.c
+++ b/libz80e/src/core/registers.c
@@ -22,10 +22,10 @@ void exx(z80registers_t *r) {
 }
 
 int parity(uint8_t x) {
-  x ^= x >> 4;
-  x ^= x >> 2;
-  x ^= x >> 1;
-  return x & 1;
+	x ^= x >> 4;
+	x ^= x >> 2;
+	x ^= x >> 1;
+	return x & 1;
 }
 
 void print_state(z80registers_t *r) {

--- a/libz80e/src/debugger/commands/stack.c
+++ b/libz80e/src/debugger/commands/stack.c
@@ -12,7 +12,7 @@ int command_stack(struct debugger_state *state, int argc, char **argv) {
 	uint16_t sp = cpu->registers.SP;
 
 	uint16_t i;
-	for (i = sp; i < sp + 20; i += 2) {
+	for (i = sp; i != (uint16_t)(sp + 20); i += 2) {
 		state->print(state, "0x%04X: 0x%04X\n", i, cpu_read_word(cpu, i));
 	}
 


### PR DESCRIPTION
In addition to other small bugfixes, causes everything but block instructions to pass zexdoc, and everything but bit and block instructions to pass zexall.