### PR TITLE
Add keybinding for calculator's '.'/':'/'i' key (bound ":" and ".")

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -79,3 +79,4 @@ Right Arrow|Right|0x02
 Down Arrow|Down|0x00
 Return|Enter|0x10
 Delete|DEL|0x67
+:/.|:|0x30

--- a/frontends/sdl/main.c
+++ b/frontends/sdl/main.c
@@ -569,6 +569,10 @@ void sdl_events_hook(asic_t *device, void * unused) {
 					case SDLK_DELETE: /* Delete = DEL */
 						key_tap(device, 0x67, event.type == SDL_KEYDOWN);
 						break;
+					case SDLK_PERIOD:
+					case SDLK_SEMICOLON:
+						key_tap(device, 0x30, event.type == SDL_KEYDOWN);
+						break;
 
 					default:
 						break;


### PR DESCRIPTION
Binds computer keyboard's period and semicolon keys to the emulated calculator's '.'/':'/'i' key.