### PR TITLE
Fixes update skip when only zeros drawn to screen.

### DIFF
--- a/libz80e/src/ti/hardware/t6a04.c
+++ b/libz80e/src/ti/hardware/t6a04.c
@@ -49,7 +49,8 @@ uint8_t bw_lcd_read_screen(ti_bw_lcd_t *lcd, int Y, int X) {
 int bw_lcd_write_screen(ti_bw_lcd_t *lcd, int Y, int X, char val) {
 	val = !!val;
 	int location = X * 120 + Y;
-	int orig = lcd->ram[location >> 3] &= ~(1 << (location % 8));
+	int orig = lcd->ram[location >> 3];
+	lcd->ram[location >> 3] &= ~(1 << (location % 8));
 	lcd->ram[location >> 3] |= (val << (location % 8));
 	
 	return orig != lcd->ram[location >> 3];


### PR DESCRIPTION
When every pixel on the screen is set (all 1's), writing a byte containing only zeros to the lcd would not trigger a refresh in the sdl gui. This PR fixes that issue.