### PR TITLE
Port SDL frontend to SDL2

### DIFF
--- a/frontends/sdl/CMakeLists.txt
+++ b/frontends/sdl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project (sdl)
 
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/../../CMake)
-find_package(SDL REQUIRED)
+find_package(SDL2 REQUIRED)
 find_package(Scas REQUIRED)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin/")
@@ -14,7 +14,7 @@ add_executable(z80e-sdl
 	$<TARGET_OBJECTS:z80e_objects>
 )
 
-TARGET_LINK_LIBRARIES(z80e-sdl readline ${SDL_LIBRARY})
+TARGET_LINK_LIBRARIES(z80e-sdl readline SDL2::SDL2)
 
 if(NOT APPLE AND NOT HAIKU)
 	TARGET_LINK_LIBRARIES(z80e-sdl rt)


### PR DESCRIPTION
Naturally, SDL2 provides various advantages, such as Wayland support.

The code is shorter now, by making use of SDL2's render API, which handles things like scaling 96x64 up to the window size for us.