### PR TITLE
Implement Z offset in SDL frontend

### DIFF
--- a/frontends/sdl/main.c
+++ b/frontends/sdl/main.c
@@ -123,7 +123,8 @@ void print_lcd(void *data, ti_bw_lcd_t *lcd) {
         SDL_RenderClear(context.renderer);
 	for (cX = 0; cX < 64; cX++) {
 		for (cY = 0; cY < 96; cY++) {
-			if (_bw_lcd_read_screen(lcd, cY, cX)) {
+			int cXZ = (cX + lcd->Z) % 64;
+			if (_bw_lcd_read_screen(lcd, cY, cXZ)) {
 				SDL_SetRenderDrawColor(context.renderer, COLOR_ON);
 			} else {
 				SDL_SetRenderDrawColor(context.renderer, COLOR_OFF);


### PR DESCRIPTION
Z offset is properly handled in libz80e, but the SDL frontend doesn't account for it. This change makes the frontend display the same thing as in the calculator (at least on my TI-84+)