### PR TITLE
cmake hotfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.5)
+cmake_policy(SET CMP0028 OLD)
 
 project(z80e C)
 


### PR DESCRIPTION
When running the KnightOS SDK installer on my Ubuntu 20.04,
compiling z80e would fail, claiming it could not link SDL2.
Upon manually compiling z80e independently, cmake issued a warning
about using `::` (run `cmake --help-policy CMP0028` for more specific details)

This commit should be a temporary fix. I would make the proper change myself,
but I am not familiar with CMake. This is just a result of my investigation.